### PR TITLE
Add == instead of =

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 # This file may be used to create an environment using:
 # $ conda create --name <env> --file <this file>
-cloudpickle=0.5.3
-matplotlib=3.1.1
-numpy=1.16
-pyyaml=5.1.2
-tqdm=4.31.1
-wheel=0.33.6
-yaml=0.1.7
-scipy=1.5.2
+cloudpickle==0.5.3
+matplotlib==3.1.1
+numpy==1.16
+pyyaml==5.1.2
+tqdm==4.31.1
+wheel==0.33.6
+yaml==0.1.7
+scipy==1.5.2


### PR DESCRIPTION
Hey, was getting the following error on Colab with Python 3.7.12

```
ERROR: Invalid requirement: 'cloudpickle=0.5.3' (from line 3 of requirements.txt)
Hint: = is not a valid operator. Did you mean == ?
```

Changing the = to == for each requirement might fix it. 